### PR TITLE
add mongo_db volume to docker-compose to allow data to persist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,7 @@ services:
     image: mongo
     ports:
       - "27017:27017"
+    volumes:
+      - mongo_db:/data/db
+volumes:
+  mongo_db: 


### PR DESCRIPTION
Sets up a volume in the top-level docker-compose for the mongo service to use to persist after downing container